### PR TITLE
support single quote in font families

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var fontRegex = new RegExp([
   '(?:(?:normal|\\1|\\2|\\3)\\s*){0,3}((?:xx?-)?',
   '(?:small|large)|medium|smaller|larger|[\\.\\d]+(?:\\%|in|[cem]m|ex|p[ctx]))',
   '(?:\\s*\\/\\s*(normal|[\\.\\d]+(?:\\%|in|[cem]m|ex|p[ctx])?))',
-  '?\\s*([-,\\"\\sa-z]+?)\\s*$'
+  '?\\s*([-,\\"\\\'\\sa-z]+?)\\s*$'
 ].join(''), 'i');
 
 

--- a/test.js
+++ b/test.js
@@ -67,6 +67,11 @@ assert.deepEqual(parse('italic small-caps bolder 10px/20px serif'), {
   family: ['serif']
 });
 
+assert.deepEqual(parse('700 18px \'Raleway\', sans-serif'), {
+  size: 18,
+  weight: '700',
+  family: ['\'Raleway\'', 'sans-serif']
+});
 
 // Generic font families
 [


### PR DESCRIPTION
@tmpvar 
this PR adds support for single quotes around font family names.