### PR TITLE
fix lineHeight parsing issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,12 @@ var parse = module.exports = function(str, existing, dpi) {
 
     if (op[key] && val) {
       var existingVal = (existing) ? existing[key] || null : null;
-      val = op[key](val, existingVal, dpi);
+      var v = op[key](val, existingVal, dpi);
+      if (typeof v === 'undefined' && key === 'lineHeight' && val) {
+        val = collected.size * parseFloat(val);
+      } else {
+        val = v;
+      }
     }
 
 

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 var parse = require('./index');
 
+
 assert.ok(!parse('inherit'));
 assert.ok(!parse('bogus'));
 assert.ok(!parse('10px {bogus}'));
@@ -56,6 +57,12 @@ assert.deepEqual(parse('italic normal bolder 10px/20px serif'), {
   size: 10,
   lineHeight: 20,
   family: ['serif']
+});
+
+assert.deepEqual(parse('16px/1.2 Georgia,serif'), {
+  size: 16,
+  lineHeight: 19.2,
+  family: ['Georgia', 'serif']
 });
 
 assert.deepEqual(parse('italic small-caps bolder 10px/20px serif'), {

--- a/test.js
+++ b/test.js
@@ -119,7 +119,7 @@ assert.equal(parse('5000% sans-serif', '12pt serif', null, 96).size, 800);
 
 // Serialization
 var o = parse('italic 400 12px/2 Unknown Font, sans-serif');
-assert.equal(o.toString(), 'italic 12px "Unknown Font", sans-serif');
+assert.equal(o.toString(), 'italic 12px/24px "Unknown Font", sans-serif');
 assert.equal(o.family.length, 2);
 assert.equal(o.family[0], 'Unknown Font');
 assert.equal(o.family[1], 'sans-serif');


### PR DESCRIPTION
this breaks a serialization test (patched to pass), but provides an escape hatch for things like `font 10px/2 serif`

 closes #3 
